### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     strategy:
       matrix: 
-        os: [windows-latest]
+        os: [windows-2025]
       fail-fast: false
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Github changes the image runners windows-latest to windows-2025

https://github.com/actions/runner-images/issues/12677