### PR TITLE
Dependency Injection tests for various providers

### DIFF
--- a/MediatR.sln
+++ b/MediatR.sln
@@ -48,6 +48,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.SimpleInje
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.Stashbox", "samples\MediatR.Examples.Stashbox\MediatR.Examples.Stashbox.csproj", "{F9148E20-5856-484C-8410-B515C6C56214}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.DependencyInjectionTests", "test\MediatR.DependencyInjectionTests\MediatR.DependencyInjectionTests.csproj", "{C761C0E2-0655-40FB-98E9-1504D03DD930}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,10 @@ Global
 		{F9148E20-5856-484C-8410-B515C6C56214}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9148E20-5856-484C-8410-B515C6C56214}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9148E20-5856-484C-8410-B515C6C56214}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C761C0E2-0655-40FB-98E9-1504D03DD930}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C761C0E2-0655-40FB-98E9-1504D03DD930}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C761C0E2-0655-40FB-98E9-1504D03DD930}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C761C0E2-0655-40FB-98E9-1504D03DD930}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -124,6 +130,7 @@ Global
 		{004D029A-43E7-47B0-BA74-D0A9F7FC7713} = {E372BF0B-90E8-4DC1-A332-F023095A3C2A}
 		{7CEB57F2-B6DC-4A18-A040-D12555C3D32F} = {E372BF0B-90E8-4DC1-A332-F023095A3C2A}
 		{F9148E20-5856-484C-8410-B515C6C56214} = {E372BF0B-90E8-4DC1-A332-F023095A3C2A}
+		{C761C0E2-0655-40FB-98E9-1504D03DD930} = {962C5ACA-AB2B-4E9B-9EBB-7E7EE28CDBB1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D58286E3-878B-4ACB-8E76-F61E708D4339}

--- a/test/MediatR.DependencyInjectionTests/Abstractions/BaseAssemblyResolutionTests.cs
+++ b/test/MediatR.DependencyInjectionTests/Abstractions/BaseAssemblyResolutionTests.cs
@@ -4,12 +4,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace MediatR.DependencyInjectionTests.Abstractions;
 
-public abstract class BaseAssemblyResolutionTests : IClassFixture<BaseServiceProviderFixture>
+public abstract class BaseAssemblyResolutionTests(BaseServiceProviderFixture fixture) : IClassFixture<BaseServiceProviderFixture>
 {
-    private readonly IServiceProvider _provider;
-
-    protected BaseAssemblyResolutionTests(BaseServiceProviderFixture fixture) =>
-        _provider = fixture.Provider;
+    private readonly IServiceProvider _provider = fixture.Provider;
 
     [Fact]
     public void Should_Resolve_Mediator() =>

--- a/test/MediatR.DependencyInjectionTests/Abstractions/BaseAssemblyResolutionTests.cs
+++ b/test/MediatR.DependencyInjectionTests/Abstractions/BaseAssemblyResolutionTests.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.DependencyInjectionTests.Abstractions;
+
+public abstract class BaseAssemblyResolutionTests : IClassFixture<BaseServiceProviderFixture>
+{
+    private readonly IServiceProvider _provider;
+
+    protected BaseAssemblyResolutionTests(BaseServiceProviderFixture fixture) =>
+        _provider = fixture.Provider;
+
+    [Fact]
+    public void Should_Resolve_Mediator() =>
+        _provider.GetService<IMediator>()
+            .ShouldNotBeNull();
+
+    #region REQUESTS
+
+    [Fact]
+    public void Should_Resolve_Public_RequestHandler() =>
+        _provider.GetService<IRequestHandler<PublicPing, Pong>>()
+            .ShouldNotBeNull();
+
+    [Fact]
+    public void Should_Resolve_Internal_RequestHandler() =>
+        _provider.GetService<IRequestHandler<InternalPing, Pong>>()
+            .ShouldNotBeNull();
+
+    [Fact]
+    public void Should_Resolve_Private_RequestHandler() =>
+        _provider.GetService<IRequestHandler<PrivatePing, Pong>>()
+            .ShouldNotBeNull();
+
+    #endregion
+
+    #region VOID_REQUESTS
+
+    [Fact]
+    public void Should_Resolve_Public_Void_RequestHandler() =>
+        _provider.GetService<IRequestHandler<PublicVoidPing>>()
+            .ShouldNotBeNull();
+
+    [Fact]
+    public void Should_Resolve_Internal_Void_RequestHandler() =>
+        _provider.GetService<IRequestHandler<InternalVoidPing>>()
+            .ShouldNotBeNull();
+
+    [Fact]
+    public void Should_Resolve_Private_Void_RequestHandler() =>
+        _provider.GetService<IRequestHandler<PrivateVoidPing>>()
+            .ShouldNotBeNull();
+
+    #endregion
+}

--- a/test/MediatR.DependencyInjectionTests/Abstractions/BaseAssemblyResolutionTests.cs
+++ b/test/MediatR.DependencyInjectionTests/Abstractions/BaseAssemblyResolutionTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using MediatR.DependencyInjectionTests.Contracts.Notifications;
+using MediatR.DependencyInjectionTests.Contracts.StreamRequests;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MediatR.DependencyInjectionTests.Abstractions;
 
@@ -13,8 +15,6 @@ public abstract class BaseAssemblyResolutionTests : IClassFixture<BaseServicePro
     public void Should_Resolve_Mediator() =>
         _provider.GetService<IMediator>()
             .ShouldNotBeNull();
-
-    #region REQUESTS
 
     [Fact]
     public void Should_Resolve_Public_RequestHandler() =>
@@ -31,10 +31,6 @@ public abstract class BaseAssemblyResolutionTests : IClassFixture<BaseServicePro
         _provider.GetService<IRequestHandler<PrivatePing, Pong>>()
             .ShouldNotBeNull();
 
-    #endregion
-
-    #region VOID_REQUESTS
-
     [Fact]
     public void Should_Resolve_Public_Void_RequestHandler() =>
         _provider.GetService<IRequestHandler<PublicVoidPing>>()
@@ -50,5 +46,24 @@ public abstract class BaseAssemblyResolutionTests : IClassFixture<BaseServicePro
         _provider.GetService<IRequestHandler<PrivateVoidPing>>()
             .ShouldNotBeNull();
 
-    #endregion
+    [Fact]
+    public void Should_Resolve_Public_Private_Internal_Notification_Handlers() =>
+        _provider.GetServices<INotificationHandler<Ding>>()
+            .Count()
+            .ShouldBe(3);
+
+    [Fact]
+    public void Should_Resolve_Public_Stream_Request_Handlers() =>
+        _provider.GetService<IStreamRequestHandler<PublicZing, Zong>>()
+            .ShouldNotBeNull();
+
+    [Fact]
+    public void Should_Resolve_Internal_Stream_Request_Handlers() =>
+        _provider.GetService<IStreamRequestHandler<InternalZing, Zong>>()
+            .ShouldNotBeNull();
+
+    [Fact]
+    public void Should_Resolve_Private_Stream_Request_Handlers() =>
+        _provider.GetService<IStreamRequestHandler<PrivateZing, Zong>>()
+            .ShouldNotBeNull();
 }

--- a/test/MediatR.DependencyInjectionTests/Abstractions/BaseServiceProviderFixture.cs
+++ b/test/MediatR.DependencyInjectionTests/Abstractions/BaseServiceProviderFixture.cs
@@ -1,0 +1,6 @@
+﻿namespace MediatR.DependencyInjectionTests.Abstractions;
+
+public class BaseServiceProviderFixture
+{
+    public virtual IServiceProvider Provider => throw new NotImplementedException();
+}

--- a/test/MediatR.DependencyInjectionTests/AutoFacDependencyInjectionTests.cs
+++ b/test/MediatR.DependencyInjectionTests/AutoFacDependencyInjectionTests.cs
@@ -1,0 +1,9 @@
+﻿using MediatR.DependencyInjectionTests.Abstractions;
+using MediatR.DependencyInjectionTests.Providers;
+
+namespace MediatR.DependencyInjectionTests;
+
+public class AutoFacDependencyInjectionTests : BaseAssemblyResolutionTests
+{
+    public AutoFacDependencyInjectionTests() : base(new AutoFacServiceProviderFixture()) { }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Notifications/Ding.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Notifications/Ding.cs
@@ -1,0 +1,22 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Notifications;
+
+public record Ding : INotification
+{
+    public class Door1 : INotificationHandler<Ding>
+    {
+        public Task Handle(Ding notification, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    internal class Door2 : INotificationHandler<Ding>
+    {
+        public Task Handle(Ding notification, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    private class Door3 : INotificationHandler<Ding>
+    {
+        public Task Handle(Ding notification, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Requests/InternalPing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Requests/InternalPing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Requests;
+
+internal record InternalPing : IRequest<Pong>
+{
+    internal class Handler : IRequestHandler<InternalPing, Pong>
+    {
+        public Task<Pong> Handle(InternalPing request, CancellationToken cancellationToken) =>
+            Task.FromResult(new Pong());
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Requests/InternalVoidPing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Requests/InternalVoidPing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Requests;
+
+internal record InternalVoidPing : IRequest
+{
+    internal class Handler : IRequestHandler<InternalVoidPing>
+    {
+        public Task Handle(InternalVoidPing request, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Requests/PrivatePing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Requests/PrivatePing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Requests;
+
+public record PrivatePing : IRequest<Pong>
+{
+    private class Handler : IRequestHandler<PrivatePing, Pong>
+    {
+        public Task<Pong> Handle(PrivatePing request, CancellationToken cancellationToken) =>
+            Task.FromResult(new Pong());
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Requests/PrivateVoidPing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Requests/PrivateVoidPing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Requests;
+
+public record PrivateVoidPing : IRequest
+{
+    private class Handler : IRequestHandler<PrivateVoidPing>
+    {
+        public Task Handle(PrivateVoidPing request, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Requests/PublicPing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Requests/PublicPing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Requests;
+
+public record PublicPing : IRequest<Pong>
+{
+    public class Handler : IRequestHandler<PublicPing, Pong>
+    {
+        public Task<Pong> Handle(PublicPing request, CancellationToken cancellationToken) =>
+            Task.FromResult(new Pong());
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Requests/PublicVoidPing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Requests/PublicVoidPing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Requests;
+
+public record PublicVoidPing : IRequest
+{
+    public class Handler : IRequestHandler<PublicVoidPing>
+    {
+        public Task Handle(PublicVoidPing request, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/Responses/Pong.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Responses/Pong.cs
@@ -1,3 +1,4 @@
 ﻿namespace MediatR.DependencyInjectionTests.Contracts.Responses;
 
 public record Pong;
+public record Zong;

--- a/test/MediatR.DependencyInjectionTests/Contracts/Responses/Pong.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/Responses/Pong.cs
@@ -1,0 +1,3 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.Responses;
+
+public record Pong;

--- a/test/MediatR.DependencyInjectionTests/Contracts/StreamRequests/InternalZing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/StreamRequests/InternalZing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.StreamRequests;
+
+internal record InternalZing : IStreamRequest<Zong>
+{
+    internal class Handler : IStreamRequestHandler<InternalZing, Zong>
+    {
+        public IAsyncEnumerable<Zong> Handle(InternalZing request, CancellationToken token) =>
+            throw new NotImplementedException();
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/StreamRequests/PrivateZing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/StreamRequests/PrivateZing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.StreamRequests;
+
+internal record PrivateZing : IStreamRequest<Zong>
+{
+    private class Handler : IStreamRequestHandler<PrivateZing, Zong>
+    {
+        public IAsyncEnumerable<Zong> Handle(PrivateZing request, CancellationToken token) =>
+            throw new NotImplementedException();
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Contracts/StreamRequests/PublicZing.cs
+++ b/test/MediatR.DependencyInjectionTests/Contracts/StreamRequests/PublicZing.cs
@@ -1,0 +1,10 @@
+﻿namespace MediatR.DependencyInjectionTests.Contracts.StreamRequests;
+
+public record PublicZing : IStreamRequest<Zong>
+{
+    public class Handler : IStreamRequestHandler<PublicZing, Zong>
+    {
+        public IAsyncEnumerable<Zong> Handle(PublicZing request, CancellationToken token) =>
+            throw new NotImplementedException();
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/DryIocDependencyInjectionTests.cs
+++ b/test/MediatR.DependencyInjectionTests/DryIocDependencyInjectionTests.cs
@@ -3,7 +3,5 @@ using MediatR.DependencyInjectionTests.Providers;
 
 namespace MediatR.DependencyInjectionTests;
 
-public class DryIocDependencyInjectionTests : BaseAssemblyResolutionTests
-{
-    public DryIocDependencyInjectionTests() : base(new DryIocServiceProviderFixture()) { }
-}
+public class DryIocDependencyInjectionTests() 
+    : BaseAssemblyResolutionTests(new DryIocServiceProviderFixture());

--- a/test/MediatR.DependencyInjectionTests/DryIocDependencyInjectionTests.cs
+++ b/test/MediatR.DependencyInjectionTests/DryIocDependencyInjectionTests.cs
@@ -1,0 +1,9 @@
+﻿using MediatR.DependencyInjectionTests.Abstractions;
+using MediatR.DependencyInjectionTests.Providers;
+
+namespace MediatR.DependencyInjectionTests;
+
+public class DryIocDependencyInjectionTests : BaseAssemblyResolutionTests
+{
+    public DryIocDependencyInjectionTests() : base(new DryIocServiceProviderFixture()) { }
+}

--- a/test/MediatR.DependencyInjectionTests/MediatR.DependencyInjectionTests.csproj
+++ b/test/MediatR.DependencyInjectionTests/MediatR.DependencyInjectionTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/test/MediatR.DependencyInjectionTests/MediatR.DependencyInjectionTests.csproj
+++ b/test/MediatR.DependencyInjectionTests/MediatR.DependencyInjectionTests.csproj
@@ -1,23 +1,34 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
 
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\MediatR\MediatR.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Shouldly" Version="4.2.1"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
+        <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0"/>
+        <PackageReference Include="Autofac" Version="7.1.0"/>
+        <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
 
 </Project>

--- a/test/MediatR.DependencyInjectionTests/MediatR.DependencyInjectionTests.csproj
+++ b/test/MediatR.DependencyInjectionTests/MediatR.DependencyInjectionTests.csproj
@@ -22,8 +22,8 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0"/>
         <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0"/>
-        <PackageReference Include="Autofac" Version="7.1.0"/>
         <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0"/>
     </ItemGroup>
 

--- a/test/MediatR.DependencyInjectionTests/MicrosoftDependencyInjectionTests.cs
+++ b/test/MediatR.DependencyInjectionTests/MicrosoftDependencyInjectionTests.cs
@@ -1,0 +1,9 @@
+﻿using MediatR.DependencyInjectionTests.Abstractions;
+using MediatR.DependencyInjectionTests.Providers;
+
+namespace MediatR.DependencyInjectionTests;
+
+public class MicrosoftDependencyInjectionTests : BaseAssemblyResolutionTests
+{
+    public MicrosoftDependencyInjectionTests() : base(new MicrosoftServiceProviderFixture()) { }
+}

--- a/test/MediatR.DependencyInjectionTests/Providers/AutoFacServiceProviderFixture.cs
+++ b/test/MediatR.DependencyInjectionTests/Providers/AutoFacServiceProviderFixture.cs
@@ -12,6 +12,7 @@ public class AutoFacServiceProviderFixture : BaseServiceProviderFixture
         get
         {
             var services = new ServiceCollection();
+            services.AddFakeLogging();
             services.AddMediatR(x => x.RegisterServicesFromAssemblyContaining(typeof(Pong)));
 
             var builder = new ContainerBuilder();

--- a/test/MediatR.DependencyInjectionTests/Providers/AutoFacServiceProviderFixture.cs
+++ b/test/MediatR.DependencyInjectionTests/Providers/AutoFacServiceProviderFixture.cs
@@ -1,0 +1,24 @@
+﻿using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using MediatR.DependencyInjectionTests.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.DependencyInjectionTests.Providers;
+
+public class AutoFacServiceProviderFixture : BaseServiceProviderFixture
+{
+    public override IServiceProvider Provider
+    {
+        get
+        {
+            var services = new ServiceCollection();
+            services.AddMediatR(x => x.RegisterServicesFromAssemblyContaining(typeof(Pong)));
+
+            var builder = new ContainerBuilder();
+            builder.Populate(services);
+
+            var container = builder.Build();
+            return new AutofacServiceProvider(container);
+        }
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Providers/DryIocServiceProviderFixture.cs
+++ b/test/MediatR.DependencyInjectionTests/Providers/DryIocServiceProviderFixture.cs
@@ -1,0 +1,19 @@
+﻿using DryIoc;
+using DryIoc.Microsoft.DependencyInjection;
+using MediatR.DependencyInjectionTests.Abstractions;
+
+namespace MediatR.DependencyInjectionTests.Providers;
+
+public class DryIocServiceProviderFixture : BaseServiceProviderFixture
+{
+    public override IServiceProvider Provider
+    {
+        get
+        {
+            var container = new Container();
+            container.RegisterMany(new[] { typeof(IMediator).GetAssembly(), typeof(Pong).GetAssembly() }, Registrator.Interfaces);
+            container.Register<IMediator, Mediator>(made: Made.Of(() => new Mediator(Arg.Of<IServiceProvider>())));
+            return container.BuildServiceProvider();
+        }
+    }
+}

--- a/test/MediatR.DependencyInjectionTests/Providers/DryIocServiceProviderFixture.cs
+++ b/test/MediatR.DependencyInjectionTests/Providers/DryIocServiceProviderFixture.cs
@@ -1,6 +1,7 @@
 ﻿using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 using MediatR.DependencyInjectionTests.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MediatR.DependencyInjectionTests.Providers;
 
@@ -10,9 +11,12 @@ public class DryIocServiceProviderFixture : BaseServiceProviderFixture
     {
         get
         {
-            var container = new Container();
-            container.RegisterMany(new[] { typeof(IMediator).GetAssembly(), typeof(Pong).GetAssembly() }, Registrator.Interfaces);
-            container.Register<IMediator, Mediator>(made: Made.Of(() => new Mediator(Arg.Of<IServiceProvider>())));
+            var services = new ServiceCollection();
+            services.AddFakeLogging();
+            services.AddMediatR(x => x.RegisterServicesFromAssemblyContaining(typeof(Pong)));
+
+            var container = new Container(Rules.MicrosoftDependencyInjectionRules);
+            container.WithDependencyInjectionAdapter(services);
             return container.BuildServiceProvider();
         }
     }

--- a/test/MediatR.DependencyInjectionTests/Providers/MicrosoftServiceProviderFixture.cs
+++ b/test/MediatR.DependencyInjectionTests/Providers/MicrosoftServiceProviderFixture.cs
@@ -6,6 +6,7 @@ namespace MediatR.DependencyInjectionTests.Providers;
 public class MicrosoftServiceProviderFixture : BaseServiceProviderFixture
 {
     public override IServiceProvider Provider => new ServiceCollection()
+        .AddFakeLogging()
         .AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(PublicPing).Assembly))
         .BuildServiceProvider();
 }

--- a/test/MediatR.DependencyInjectionTests/Providers/MicrosoftServiceProviderFixture.cs
+++ b/test/MediatR.DependencyInjectionTests/Providers/MicrosoftServiceProviderFixture.cs
@@ -1,0 +1,11 @@
+﻿using MediatR.DependencyInjectionTests.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.DependencyInjectionTests.Providers;
+
+public class MicrosoftServiceProviderFixture : BaseServiceProviderFixture
+{
+    public override IServiceProvider Provider => new ServiceCollection()
+        .AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(PublicPing).Assembly))
+        .BuildServiceProvider();
+}

--- a/test/MediatR.DependencyInjectionTests/Usings.cs
+++ b/test/MediatR.DependencyInjectionTests/Usings.cs
@@ -1,0 +1,3 @@
+﻿global using MediatR.DependencyInjectionTests.Contracts.Requests;
+global using MediatR.DependencyInjectionTests.Contracts.Responses;
+global using Shouldly;


### PR DESCRIPTION
Reopening #1071 since, MediatR is active again.

Dependency Injection tests for various providers like:

- `Microsoft.Extensions.DependencyInjection`
- `AutoFac`
- `DryIoC`

Used `xUnit.net` fixtures to abstract away the `IServiceProvider`, and tests are also abstracted.


If this looks good, then I can:

- Add the remaining providers in the `samples/`.
- Add tests for Generic implementations.
- Add tests for pipelines, and behaviours.
