### PR TITLE
Attach NuGet packages and SBOM to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
   MINVERBUILDMETADATA: build.${{ github.run_id }}.${{ github.run_attempt}}
 permissions:
   id-token: write
-  contents: read
+  contents: write
   checks: write
 jobs:
   build:
@@ -84,6 +84,17 @@ jobs:
         NUGET_URL: https://api.nuget.org/v3/index.json
         NUGET_API_KEY: ${{ secrets.MEDIATR_NUGET_API_KEY }}
       run: ./Push.ps1
+      shell: pwsh
+    - name: Attach assets to GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $assets = @()
+        $assets += Get-ChildItem ./artifacts -Filter *.nupkg | ForEach-Object { $_.FullName }
+        $assets += Get-ChildItem ./artifacts -Filter *.snupkg | ForEach-Object { $_.FullName }
+        $assets += './artifacts/_manifest/spdx_2.2/manifest.spdx.json'
+        $assets += './artifacts/_manifest/spdx_2.2/manifest.spdx.json.sha256'
+        gh release upload ${{ github.ref_name }} $assets --clobber
       shell: pwsh
     - name: Artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Grants `contents: write` to the Release workflow so it can attach assets to the release the maintainer creates in the UI.
- Adds an "Attach assets to GitHub Release" step in the `build` job that uses the preinstalled `gh` CLI to upload the signed `*.nupkg`, `*.snupkg`, and SBOM (`manifest.spdx.json` + `.sha256`) to the release for the pushed tag. Runs after Push to NuGet, uses `--clobber` so re-runs of the same tag refresh assets instead of failing.

## Test plan
No safe pre-merge rehearsal: the workflow triggers on any `*.*.*` tag and the new step runs *after* Push to MyGet/NuGet, so a throwaway tag like `99.0.0-test1` would publish a real package to NuGet.org (which only allows unlisting, not deletion within 72 hours).

Verification happens on the next real release:
- [ ] After the next release, confirm the "Attach assets to GitHub Release" step succeeds.
- [ ] Confirm four assets land on the release page: `MediatR.<ver>.nupkg`, `MediatR.<ver>.snupkg`, `manifest.spdx.json`, `manifest.spdx.json.sha256`.

If the new step fails, the packages are already on the public feeds; re-run the job (idempotent via `--clobber`) or run `gh release upload <tag> <files> --clobber` locally as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)