### PR TITLE
Treat blank license key as unconfigured (#1170)

### DIFF
--- a/src/MediatR/Licensing/LicenseAccessor.cs
+++ b/src/MediatR/Licensing/LicenseAccessor.cs
@@ -42,15 +42,14 @@ internal class LicenseAccessor
             }
 
             var key = _configuration?.LicenseKey
-                      ?? Mediator.LicenseKey
-                      ?? null;
-            
-            if (key == null)
+                      ?? Mediator.LicenseKey;
+
+            if (string.IsNullOrWhiteSpace(key))
             {
                 return new License();
             }
 
-            var licenseClaims = ValidateKey(key);
+            var licenseClaims = ValidateKey(key!);
             return licenseClaims.Any() 
                 ? new License(new ClaimsPrincipal(new ClaimsIdentity(licenseClaims))) 
                 : new License();

--- a/test/MediatR.Tests/Licensing/LicenseAccessorTests.cs
+++ b/test/MediatR.Tests/Licensing/LicenseAccessorTests.cs
@@ -1,0 +1,59 @@
+using MediatR.Licensing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Shouldly;
+using Xunit;
+
+namespace MediatR.Tests.Licensing;
+
+public class LicenseAccessorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Should_return_unconfigured_license_for_missing_or_blank_key(string? key)
+    {
+        var factory = new LoggerFactory();
+        var provider = new FakeLoggerProvider();
+        factory.AddProvider(provider);
+
+        var config = new MediatRServiceConfiguration { LicenseKey = key };
+        var accessor = new LicenseAccessor(config, factory);
+
+        var license = accessor.Current;
+
+        license.IsConfigured.ShouldBeFalse();
+
+        var logMessages = provider.Collector.GetSnapshot();
+        logMessages.ShouldNotContain(log => log.Level == LogLevel.Critical);
+    }
+
+    [Fact]
+    public void Should_return_unconfigured_license_when_static_key_is_blank()
+    {
+        var factory = new LoggerFactory();
+        var provider = new FakeLoggerProvider();
+        factory.AddProvider(provider);
+
+        var original = Mediator.LicenseKey;
+        try
+        {
+            Mediator.LicenseKey = "   ";
+            var accessor = new LicenseAccessor(factory);
+
+            var license = accessor.Current;
+
+            license.IsConfigured.ShouldBeFalse();
+
+            var logMessages = provider.Collector.GetSnapshot();
+            logMessages.ShouldNotContain(log => log.Level == LogLevel.Critical);
+        }
+        finally
+        {
+            Mediator.LicenseKey = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1170.

When `MediatRServiceConfiguration.LicenseKey` (or the static `Mediator.LicenseKey`) was set to an empty or whitespace-only string, `LicenseAccessor.Initialize()` passed it straight into `JsonWebTokenHandler.ValidateTokenAsync`, which throws `ArgumentNullException` (`IDX10000: The parameter 'token' cannot be a 'null' or an empty object`). That got logged as **FATAL/Critical**, immediately followed by the normal "no valid license" warning — two alarming messages for a benign cause (commonly a config/env-var binding that resolved to `""`).

## Change

- `src/MediatR/Licensing/LicenseAccessor.cs`: use `string.IsNullOrWhiteSpace(key)` instead of `key == null`, so blank keys fall through to the unconfigured-license path (warning only, no FATAL).

## Tests

- `test/MediatR.Tests/Licensing/LicenseAccessorTests.cs` (new): theory covering `null`, `""`, `"   "`, `"\t"` plus a case for the static `Mediator.LicenseKey`, asserting the license is unconfigured and no Critical log is emitted.

All licensing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)