### PR TITLE
ci: publish fork-PR test reports via workflow_run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,13 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   MINVERBUILDMETADATA: build.${{ github.run_id }}.${{ github.run_attempt}}
+# This workflow runs untrusted code from fork PRs, so it keeps a read-only token
+# and never needs secrets. Test results are published by a separate workflow
+# (test-report.yml, triggered via workflow_run) that runs in the base-repo
+# context with checks:write. See issue #1172.
 permissions:
   id-token: write
   contents: read
-  checks: write
 jobs:
   build:
     runs-on: windows-latest
@@ -35,13 +38,14 @@ jobs:
     - name: Build and Test
       run: ./Build.ps1
       shell: pwsh
-    - name: Report Test Results
-      uses: dorny/test-reporter@v1.9.1
+    - name: Upload Test Results
+      # Publishing happens in test-report.yml, which downloads this artifact.
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: Test Results (Windows)
+        name: test-results-Windows
         path: '**/TestResults/**/*.trx'
-        reporter: dotnet-trx
+        if-no-files-found: ignore
     - name: Get package version
       id: version
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,13 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   MINVERBUILDMETADATA: build.${{ github.run_id }}.${{ github.run_attempt}}
-# This workflow runs untrusted code from fork PRs, so it keeps a read-only token
-# and never needs secrets. Test results are published by a separate workflow
-# (test-report.yml, triggered via workflow_run) that runs in the base-repo
-# context with checks:write. See issue #1172.
+# On pull requests — especially from forks, where GitHub forces the token to
+# read-only — this workflow needs no secrets and only read access: it builds,
+# tests, and uploads .trx artifacts. Test results are published by a separate
+# workflow (test-report.yml, triggered via workflow_run) that runs in the
+# base-repo context with checks:write. The only secret is used by the main-only
+# Push to MyGet step. CI does not use OIDC, so no id-token. See issue #1172.
 permissions:
-  id-token: write
   contents: read
 jobs:
   build:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,36 @@
+name: Test Report
+
+# Publishes test results for runs of the CI workflow, including pull requests
+# from forks. The CI workflow itself runs with a read-only token (GitHub forces
+# this for fork PRs) and only uploads the .trx files as artifacts. This workflow
+# is triggered by workflow_run, so it runs in the *base repository* context with
+# a writable token and can call the Checks API to publish inline reports.
+# See issue #1172.
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Test Results
+        uses: dorny/test-reporter@v1.9.1
+        with:
+          # Download every test-results-* artifact from the triggering CI run and
+          # publish one check per platform, e.g. "Test Results (Windows)".
+          artifact: /test-results-(.*)/
+          name: Test Results ($1)
+          path: '**/*.trx'
+          reporter: dotnet-trx
+          # A build that fails before producing any .trx shouldn't make this
+          # report red; the CI run already reflects that failure.
+          fail-on-empty: 'false'


### PR DESCRIPTION
Fixes the fork-PR CI failure tracked in #1172, using the same `workflow_run` pattern just adopted in AutoMapper (LuckyPennySoftware/AutoMapper#4643). Fork PRs get **real inline test reports** instead of a swallowed failure.

> **Note:** this branch now carries the full fix and **supersedes** the earlier `continue-on-error` stop-gap that was originally on it.

## Problem

For `pull_request` runs from a **fork**, GitHub forcibly downgrades `GITHUB_TOKEN` to read-only. `dorny/test-reporter` calls the Checks API to publish results, which needs `checks: write`; with a read-only token it gets `403 Resource not accessible by integration` and (default `fail-on-error: true`) fails the job even when all tests pass.

## Fix — split building from reporting

**`ci.yml`** (runs on the PR, read-only token, no secrets):
- Replaces the `Report Test Results` step with `Upload Test Results` — the `.trx` files are uploaded as a `test-results-Windows` artifact.
- Drops `checks: write` from `permissions`; the build no longer touches the Checks API. `Push to MyGet` stays `main`-only.

**`test-report.yml`** (new, triggered by `workflow_run` when CI completes):
- Runs in the **base-repository** context with `checks: write`, so it has a writable token even for fork PRs.
- Downloads the `test-results-*` artifacts and publishes one inline check per platform (`Test Results (Windows)`).
- `fail-on-empty: false` so a build that fails before producing `.trx` doesn't add a spurious red report.

## Rollout note

`workflow_run` only fires for the copy of `test-report.yml` on the **default branch**, so reports for fork PRs start working once this lands on `main`.

Closes #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)