### PR TITLE
Run license validation off the Mediator construction path

### DIFF
--- a/src/MediatR/Licensing/LicenseAccessor.cs
+++ b/src/MediatR/Licensing/LicenseAccessor.cs
@@ -80,7 +80,11 @@ internal class LicenseAccessor
             ValidateLifetime = false
         };
 
-        var validateResult = Task.Run(() => handler.ValidateTokenAsync(licenseKey, parms)).GetAwaiter().GetResult();
+        // Runs on the dedicated background thread started during Mediator construction
+        // (see MediatRServiceCollectionExtensions.CheckLicense / AutoMapper #4640), so there is
+        // no SynchronizationContext to deadlock on; local JWT validation completes synchronously,
+        // so this does not depend on the thread pool.
+        var validateResult = handler.ValidateTokenAsync(licenseKey, parms).GetAwaiter().GetResult();
         if (!validateResult.IsValid)
         {
             _logger.LogCritical(validateResult.Exception, "Error validating the Lucky Penny software license key");

--- a/src/MediatR/MicrosoftExtensionsDI/MediatRServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatRServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using MediatR;
 using MediatR.Licensing;
 using MediatR.Pipeline;
@@ -60,16 +62,44 @@ public static class MediatRServiceCollectionExtensions
     
     internal static void CheckLicense(this IServiceProvider serviceProvider)
     {
-        if (LicenseChecked == false)
+        if (LicenseChecked)
         {
-            var licenseAccessor = serviceProvider.GetRequiredService<LicenseAccessor>();
-            var licenseValidator = serviceProvider.GetRequiredService<LicenseValidator>();
-            
+            return;
+        }
+
+        // Resolve the license services synchronously so a missing registration still surfaces
+        // on the caller. The resolutions are cheap; only the JWT validation below is expensive.
+        var licenseAccessor = serviceProvider.GetRequiredService<LicenseAccessor>();
+        var licenseValidator = serviceProvider.GetRequiredService<LicenseValidator>();
+
+        LicenseChecked = true;
+
+        // License validation is logging-only — it gates no Mediator behavior. Running it on the
+        // Mediator construction path is unsafe: under a lazily-built DI singleton the container
+        // holds its build lock, and a cold-start thread-pool starvation then deadlocks the whole
+        // app (same root cause as AutoMapper #4640, which used Task.Run(...).GetResult() under a
+        // singleton-build lock). Offload the JWT validation to a dedicated background thread.
+        _ = Task.Factory.StartNew(
+            () => ValidateLicense(serviceProvider, licenseAccessor, licenseValidator),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning, // dedicated thread, never the (possibly starved) pool
+            TaskScheduler.Default);          // honor LongRunning regardless of the ambient scheduler
+    }
+
+    private static void ValidateLicense(IServiceProvider serviceProvider, LicenseAccessor licenseAccessor, LicenseValidator licenseValidator)
+    {
+        try
+        {
             var license = licenseAccessor.Current;
             licenseValidator.Validate(license);
         }
-
-        LicenseChecked = true;
+        catch (Exception ex)
+        {
+            // Never let a fire-and-forget failure surface as an unobserved task exception.
+            serviceProvider.GetService<ILoggerFactory>()?
+                .CreateLogger("LuckyPennySoftware.MediatR.License")
+                .LogError(ex, "Error validating the Lucky Penny software license key");
+        }
     }
 
     internal static bool LicenseChecked { get; set; }

--- a/test/MediatR.Tests/Licensing/LicenseValidationBackgroundTests.cs
+++ b/test/MediatR.Tests/Licensing/LicenseValidationBackgroundTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using MediatR.Licensing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace MediatR.Tests.Licensing;
+
+// Shares the non-parallel ServiceFactory collection because it mutates the static
+// MediatRServiceCollectionExtensions.LicenseChecked flag.
+[Collection(nameof(ServiceFactoryCollectionBehavior))]
+public class LicenseValidationBackgroundTests
+{
+    // Regression test for the license-validation deadlock (AutoMapper #4640, same root cause):
+    // validation must not run on the Mediator construction thread. Constructing a Mediator under
+    // a lazily-built DI singleton holds the container's build lock, and validating there could
+    // deadlock the whole app under a cold-start thread-pool starvation. Validation is logging-only,
+    // so it is offloaded to a dedicated background thread. Rather than clamp the global thread pool
+    // (flaky, process-wide), we assert the property that makes the deadlock impossible: constructing
+    // the Mediator returns without validating, and validation logs on a *different* thread.
+    [Fact]
+    public void License_validation_runs_off_the_construction_thread()
+    {
+        MediatRServiceCollectionExtensions.LicenseChecked = false;
+
+        var loggerProvider = new ThreadCapturingLoggerProvider();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ILoggerProvider>(loggerProvider);
+        services.AddTransient<IMediator, Mediator>();
+        // A non-empty (junk) key forces the validation path to run; its result is logged.
+        services.AddSingleton(new MediatRServiceConfiguration { LicenseKey = "not-a-real-license-key" });
+        services.AddSingleton<LicenseAccessor>();
+        services.AddSingleton<LicenseValidator>();
+
+        var container = services.BuildServiceProvider();
+
+        var constructingThreadId = Environment.CurrentManagedThreadId;
+
+        _ = container.GetRequiredService<IMediator>(); // constructs Mediator -> CheckLicense
+
+        // Construction returned without blocking on validation; the license log should arrive
+        // shortly, on a thread other than the one that constructed the Mediator.
+        loggerProvider.LicenseLogged.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+        loggerProvider.LoggingThreadId.ShouldNotBe(constructingThreadId);
+    }
+
+    private sealed class ThreadCapturingLoggerProvider : ILoggerProvider
+    {
+        public readonly ManualResetEventSlim LicenseLogged = new(false);
+        public int LoggingThreadId;
+
+        public ILogger CreateLogger(string categoryName) =>
+            categoryName == "LuckyPennySoftware.MediatR.License"
+                ? new CapturingLogger(this)
+                : NullLogger.Instance;
+
+        public void Dispose() => LicenseLogged.Dispose();
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly ThreadCapturingLoggerProvider _owner;
+
+            public CapturingLogger(ThreadCapturingLoggerProvider owner) => _owner = owner;
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                _owner.LoggingThreadId = Environment.CurrentManagedThreadId;
+                _owner.LicenseLogged.Set();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ports the AutoMapper #4640 fix ([AutoMapper#4645](https://github.com/LuckyPennySoftware/AutoMapper/pull/4645)) to MediatR, which ships the same `LicenseAccessor` and has the same deadlock.

## Problem

`Mediator`'s constructor calls `serviceProvider.CheckLicense()`, which runs `LicenseAccessor.ValidateKey`:

```csharp
var validateResult = Task.Run(() => handler.ValidateTokenAsync(licenseKey, parms))
    .GetAwaiter().GetResult();
```

`LicenseAccessor` is a lazily-built singleton, so on the first `Mediator` construction this runs while the DI container holds its singleton-build lock. `Task.Run` queues work to the thread pool and `.GetResult()` blocks the calling thread until it completes. During a cold start that takes immediate traffic, the pool is saturated — so the queued validation can never be scheduled, the lock holder blocks forever, and the whole app convoys behind it. Same root cause and mechanism as the AutoMapper production dump in #4640.

## Key insight

The validated license is **logging-only** — `LicenseValidator.Validate` just emits log messages and gates no Mediator behavior. So validation needn't be synchronous and can move off the construction path.

## Fix

- **`CheckLicense`** still resolves `LicenseAccessor` / `LicenseValidator` synchronously (cheap DI resolutions — and this preserves the existing behavior where a missing registration surfaces on the caller, covered by `Should_throw_when_missing_required_configuration`). It then offloads the JWT validation + logging to a dedicated `LongRunning` thread (`Task.Factory.StartNew` + `TaskScheduler.Default`) and returns immediately. The construction thread never blocks under the DI lock, so it can't deadlock regardless of pool state. The body is wrapped in try/catch so a faulted fire-and-forget task can't surface as an unobserved exception.
- **`LicenseAccessor.ValidateKey`** drops the `Task.Run` wrapper now that validation always runs on that dedicated background thread.

### Behavior change

License log lines now appear shortly after the first `Mediator` is constructed rather than synchronously during construction. No functional impact — Mediator behavior never depends on the license.

## Tests

- New `LicenseValidationBackgroundTests` asserts validation logs on a **different thread** than the constructor's. Verified it **fails** on the old synchronous behavior and **passes** here.
- Full suite green: MediatR.Tests 179 passed / 4 skipped / 0 failed, DI tests 66/66. Clean under `TreatWarningsAsErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)