### PR TITLE
Support license key via environment variable fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,19 @@ Mediator.LicenseKey = "<license key here>";
 > Turn off the license warning by configuring logging in your logging start configuration:
 > `builder.Logging.AddFilter("LuckyPennySoftware.MediatR.License", LogLevel.None);`
 
+#### Auto-discovery via environment variables
+
+If no license key is set in code, MediatR looks for one in environment variables. This is convenient for containerized and cloud environments, and for enterprises that share a single key across many services without code changes:
+
+- `MEDIATR_LICENSE_KEY` – the MediatR-specific license key.
+- `LUCKYPENNY_LICENSE_KEY` – a shared key usable across Lucky Penny products (for example, [AutoMapper](https://github.com/LuckyPennySoftware/AutoMapper) reads the same variable). Because it is shared, the key must be for a license that includes MediatR (a `Bundle` or MediatR edition); an AutoMapper-only license will not validate here.
+
+The license key is resolved in the following order of precedence, using the first value found:
+
+1. An explicit value set in code (`cfg.LicenseKey` or `Mediator.LicenseKey`).
+2. The `MEDIATR_LICENSE_KEY` environment variable.
+3. The `LUCKYPENNY_LICENSE_KEY` environment variable.
+
+No code change is required when using an environment variable—just register MediatR as usual without setting the license key.
+
 You can register for your license key at [MediatR.io](https://mediatr.io)

--- a/src/MediatR/Licensing/LicenseAccessor.cs
+++ b/src/MediatR/Licensing/LicenseAccessor.cs
@@ -13,6 +13,9 @@ namespace MediatR.Licensing;
 
 internal class LicenseAccessor
 {
+    internal const string MediatRLicenseKeyEnvVariable = "MEDIATR_LICENSE_KEY";
+    internal const string SharedLicenseKeyEnvVariable = "LUCKYPENNY_LICENSE_KEY";
+
     private readonly MediatRServiceConfiguration? _configuration;
     private readonly ILogger _logger;
 
@@ -41,8 +44,7 @@ internal class LicenseAccessor
                 return _license;
             }
 
-            var key = _configuration?.LicenseKey
-                      ?? Mediator.LicenseKey;
+            var key = ResolveLicenseKey(_configuration?.LicenseKey, Mediator.LicenseKey);
 
             if (string.IsNullOrWhiteSpace(key))
             {
@@ -56,6 +58,19 @@ internal class LicenseAccessor
         }
     }
     
+    /// <summary>
+    /// Resolves the license key using the first non-blank value, in order of precedence: the
+    /// explicitly configured keys (the <see cref="MediatRServiceConfiguration.LicenseKey"/> then the
+    /// static <see cref="Mediator.LicenseKey"/>), the product-specific <c>MEDIATR_LICENSE_KEY</c>
+    /// environment variable, then the shared <c>LUCKYPENNY_LICENSE_KEY</c> environment variable
+    /// (usable across Lucky Penny products).
+    /// </summary>
+    internal static string? ResolveLicenseKey(params string?[] explicitKeys) =>
+        explicitKeys
+            .Append(Environment.GetEnvironmentVariable(MediatRLicenseKeyEnvVariable))
+            .Append(Environment.GetEnvironmentVariable(SharedLicenseKeyEnvVariable))
+            .FirstOrDefault(key => !string.IsNullOrWhiteSpace(key));
+
     private Claim[] ValidateKey(string licenseKey)
     {
         var handler = new JsonWebTokenHandler();

--- a/src/MediatR/Licensing/LicenseAccessor.cs
+++ b/src/MediatR/Licensing/LicenseAccessor.cs
@@ -65,11 +65,19 @@ internal class LicenseAccessor
     /// environment variable, then the shared <c>LUCKYPENNY_LICENSE_KEY</c> environment variable
     /// (usable across Lucky Penny products).
     /// </summary>
-    internal static string? ResolveLicenseKey(params string?[] explicitKeys) =>
-        explicitKeys
-            .Append(Environment.GetEnvironmentVariable(MediatRLicenseKeyEnvVariable))
-            .Append(Environment.GetEnvironmentVariable(SharedLicenseKeyEnvVariable))
-            .FirstOrDefault(key => !string.IsNullOrWhiteSpace(key));
+    internal static string? ResolveLicenseKey(params string?[] explicitKeys)
+    {
+        var explicitKey = explicitKeys.FirstOrDefault(key => !string.IsNullOrWhiteSpace(key));
+        if (explicitKey != null)
+        {
+            return explicitKey;
+        }
+
+        return FirstConfigured(Environment.GetEnvironmentVariable(MediatRLicenseKeyEnvVariable))
+               ?? FirstConfigured(Environment.GetEnvironmentVariable(SharedLicenseKeyEnvVariable));
+
+        static string? FirstConfigured(string? key) => string.IsNullOrWhiteSpace(key) ? null : key;
+    }
 
     private Claim[] ValidateKey(string licenseKey)
     {

--- a/test/MediatR.Tests/Licensing/LicenseKeyEnvironmentVariableTests.cs
+++ b/test/MediatR.Tests/Licensing/LicenseKeyEnvironmentVariableTests.cs
@@ -1,0 +1,96 @@
+using System;
+using MediatR.Licensing;
+using Shouldly;
+using Xunit;
+
+namespace MediatR.Tests.Licensing;
+
+// Mutates process-global environment variables, so it must not run alongside
+// other tests that read them. Disable parallelization for this class.
+[Collection(nameof(LicenseKeyEnvironmentVariableTests))]
+[CollectionDefinition(nameof(LicenseKeyEnvironmentVariableTests), DisableParallelization = true)]
+public class LicenseKeyEnvironmentVariableTests
+{
+    private const string MediatREnvVar = LicenseAccessor.MediatRLicenseKeyEnvVariable;
+    private const string SharedEnvVar = LicenseAccessor.SharedLicenseKeyEnvVariable;
+
+    [Fact]
+    public void ExplicitKey_TakesPrecedence_OverBothEnvironmentVariables()
+    {
+        const string explicitKey = "explicit-license-key";
+        WithEnvironment(mediatR: "env-mediatr-key", shared: "env-shared-key", () =>
+            LicenseAccessor.ResolveLicenseKey(explicitKey).ShouldBe(explicitKey));
+    }
+
+    [Fact]
+    public void ConfigurationKey_TakesPrecedence_OverStaticKey()
+    {
+        const string configKey = "config-license-key";
+        WithEnvironment(mediatR: null, shared: null, () =>
+            LicenseAccessor.ResolveLicenseKey(configKey, "static-license-key").ShouldBe(configKey));
+    }
+
+    [Fact]
+    public void StaticKey_Used_WhenConfigurationKeyIsBlank()
+    {
+        const string staticKey = "static-license-key";
+        WithEnvironment(mediatR: null, shared: null, () =>
+            LicenseAccessor.ResolveLicenseKey("   ", staticKey).ShouldBe(staticKey));
+    }
+
+    [Fact]
+    public void MediatREnvironmentVariable_Used_WhenNoExplicitKey()
+    {
+        const string mediatRKey = "env-mediatr-key";
+        WithEnvironment(mediatR: mediatRKey, shared: null, () =>
+            LicenseAccessor.ResolveLicenseKey(null, null).ShouldBe(mediatRKey));
+    }
+
+    [Fact]
+    public void SharedEnvironmentVariable_Used_WhenOnlyItIsSet()
+    {
+        const string sharedKey = "env-shared-key";
+        WithEnvironment(mediatR: null, shared: sharedKey, () =>
+            LicenseAccessor.ResolveLicenseKey(null, null).ShouldBe(sharedKey));
+    }
+
+    [Fact]
+    public void MediatREnvironmentVariable_TakesPrecedence_OverSharedEnvironmentVariable()
+    {
+        const string mediatRKey = "env-mediatr-key";
+        WithEnvironment(mediatR: mediatRKey, shared: "env-shared-key", () =>
+            LicenseAccessor.ResolveLicenseKey(null, null).ShouldBe(mediatRKey));
+    }
+
+    [Fact]
+    public void EnvironmentVariable_Used_WhenExplicitKeysAreBlank()
+    {
+        const string mediatRKey = "env-mediatr-key";
+        WithEnvironment(mediatR: mediatRKey, shared: null, () =>
+            LicenseAccessor.ResolveLicenseKey("", "   ").ShouldBe(mediatRKey));
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenNothingIsSet()
+    {
+        WithEnvironment(mediatR: null, shared: null, () =>
+            LicenseAccessor.ResolveLicenseKey(null, null).ShouldBeNull());
+    }
+
+    private static void WithEnvironment(string? mediatR, string? shared, Action assert)
+    {
+        var originalMediatR = Environment.GetEnvironmentVariable(MediatREnvVar);
+        var originalShared = Environment.GetEnvironmentVariable(SharedEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(MediatREnvVar, mediatR);
+            Environment.SetEnvironmentVariable(SharedEnvVar, shared);
+            assert();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MediatREnvVar, originalMediatR);
+            Environment.SetEnvironmentVariable(SharedEnvVar, originalShared);
+        }
+    }
+}

--- a/test/MediatR.Tests/Licensing/LicenseKeyEnvironmentVariableTests.cs
+++ b/test/MediatR.Tests/Licensing/LicenseKeyEnvironmentVariableTests.cs
@@ -5,10 +5,12 @@ using Xunit;
 
 namespace MediatR.Tests.Licensing;
 
+[CollectionDefinition(nameof(LicenseKeyEnvironmentVariableCollection), DisableParallelization = true)]
+public class LicenseKeyEnvironmentVariableCollection {}
+
 // Mutates process-global environment variables, so it must not run alongside
-// other tests that read them. Disable parallelization for this class.
-[Collection(nameof(LicenseKeyEnvironmentVariableTests))]
-[CollectionDefinition(nameof(LicenseKeyEnvironmentVariableTests), DisableParallelization = true)]
+// other tests that read them. Disable parallelization via the collection above.
+[Collection(nameof(LicenseKeyEnvironmentVariableCollection))]
 public class LicenseKeyEnvironmentVariableTests
 {
     private const string MediatREnvVar = LicenseAccessor.MediatRLicenseKeyEnvVariable;


### PR DESCRIPTION
## What Changed

Added support for reading the MediatR license key from an environment variable instead of requiring it to be set in code. Ports [LuckyPennySoftware/AutoMapper#4634](https://github.com/LuckyPennySoftware/AutoMapper/pull/4634) to MediatR.

## Why

In containerized and cloud environments it's preferable to supply sensitive configuration through environment variables rather than hardcoding it. It also lets enterprises share a single key across many services without code changes.

## How It Works

If no license key is set in code, MediatR resolves one from environment variables. The key is resolved using the **first non-blank value** in this order of precedence:

1. An explicit value set in code (`cfg.LicenseKey` or `Mediator.LicenseKey`).
2. The `MEDIATR_LICENSE_KEY` environment variable (product-specific).
3. The `LUCKYPENNY_LICENSE_KEY` environment variable (shared across Lucky Penny products; for example, AutoMapper reads the same variable).

Blank/whitespace values are treated as unconfigured and fall through, consistent with #1170.

## Notes on adapting from the AutoMapper PR

- MediatR has **two** explicit key sources (the config instance and static `Mediator.LicenseKey`) where AutoMapper has one, so `ResolveLicenseKey` accepts `params string?[]` to cover both.
- Preserved MediatR's blank-as-unconfigured semantics: the resolver skips blank values rather than only null ones, so a blank explicit key correctly falls through to the environment variables.
- The AutoMapper PR's `ci.yml` changes were **not** ported — they're AutoMapper-specific, and MediatR already has fork-safe CI (commits b28cfac, 329ce79).

## Tests

New `LicenseKeyEnvironmentVariableTests` covering explicit-key precedence, config-vs-static precedence, per-variable fallback, blank handling, and the all-unset case. Parallelization is disabled for the class since it mutates process-global environment variables.

## Backward Compatibility

100% backward compatible — existing code that sets the license key continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)